### PR TITLE
Updated the Cloud Coverage and Rain Level sliders to increment by 0.05 instead of just 0.1.

### DIFF
--- a/ACC Dedicated Server GUI/MainForm.Designer.cs
+++ b/ACC Dedicated Server GUI/MainForm.Designer.cs
@@ -1287,12 +1287,13 @@
             // 
             this.rainTrackBar.LargeChange = 1;
             this.rainTrackBar.Location = new System.Drawing.Point(122, 58);
+            this.rainTrackBar.Maximum = 20;
             this.rainTrackBar.Name = "rainTrackBar";
             this.rainTrackBar.Size = new System.Drawing.Size(181, 45);
             this.rainTrackBar.TabIndex = 35;
             this.rainTrackBar.TabStop = false;
             this.rainTrackBar.TickStyle = System.Windows.Forms.TickStyle.None;
-            this.rainTrackBar.Value = 4;
+            this.rainTrackBar.Value = 8;
             this.rainTrackBar.Scroll += new System.EventHandler(this.rainTrackBar_Scroll);
             this.rainTrackBar.ValueChanged += new System.EventHandler(this.rainTrackBar_Scroll);
             // 
@@ -1320,12 +1321,13 @@
             // 
             this.cloudCoverageTrackBar.LargeChange = 1;
             this.cloudCoverageTrackBar.Location = new System.Drawing.Point(122, 33);
+            this.cloudCoverageTrackBar.Maximum = 20;
             this.cloudCoverageTrackBar.Name = "cloudCoverageTrackBar";
             this.cloudCoverageTrackBar.Size = new System.Drawing.Size(181, 45);
             this.cloudCoverageTrackBar.TabIndex = 32;
             this.cloudCoverageTrackBar.TabStop = false;
             this.cloudCoverageTrackBar.TickStyle = System.Windows.Forms.TickStyle.None;
-            this.cloudCoverageTrackBar.Value = 3;
+            this.cloudCoverageTrackBar.Value = 6;
             this.cloudCoverageTrackBar.Scroll += new System.EventHandler(this.cloudCoverageTrackBar_Scroll);
             this.cloudCoverageTrackBar.ValueChanged += new System.EventHandler(this.cloudCoverageTrackBar_Scroll);
             // 

--- a/ACC Dedicated Server GUI/MainForm.cs
+++ b/ACC Dedicated Server GUI/MainForm.cs
@@ -44,7 +44,7 @@ namespace ACC_Dedicated_Server_GUI
         const int SC_MAXIMIZE = 61488;
 
         public string title = "ACC Dedicated Server GUI ";
-        public string version = "V1.2.8.6";
+        public string version = "V1.2.8.7";
 
         public static List<Car> carList = new List<Car>()
         {
@@ -150,12 +150,12 @@ namespace ACC_Dedicated_Server_GUI
 
         private void cloudCoverageTrackBar_Scroll(object sender, EventArgs e)
         {
-            cloudCoverageLabel.Text = ((float)cloudCoverageTrackBar.Value / 10).ToString("0.0#");
+            cloudCoverageLabel.Text = ((float)cloudCoverageTrackBar.Value / cloudCoverageTrackBar.Maximum).ToString("0.0#");
         }
 
         private void rainTrackBar_Scroll(object sender, EventArgs e)
         {
-            rainLabel.Text = ((float)rainTrackBar.Value / 10).ToString("0.0#");
+            rainLabel.Text = ((float)rainTrackBar.Value / rainTrackBar.Maximum).ToString("0.0#");
         }
 
         private void weatherRandomnessTrackBar_Scroll(object sender, EventArgs e)
@@ -297,8 +297,8 @@ namespace ACC_Dedicated_Server_GUI
                 postRaceWaitTimeNumericUpDown.Value = InNumUpDnRange(eventObject.postRaceSeconds, postRaceWaitTimeNumericUpDown);
                 overTimeNumericUpDown.Value = InNumUpDnRange(eventObject.sessionOverTimeSeconds, overTimeNumericUpDown);
                 tempTrackBar.Value = InTrackBarRange(eventObject.ambientTemp, tempTrackBar);
-                cloudCoverageTrackBar.Value = InTrackBarRange((int)(eventObject.cloudLevel * 10), cloudCoverageTrackBar);
-                rainTrackBar.Value = InTrackBarRange((int)(eventObject.rain * 10), rainTrackBar);
+                cloudCoverageTrackBar.Value = InTrackBarRange((int)(eventObject.cloudLevel * cloudCoverageTrackBar.Maximum), cloudCoverageTrackBar);
+                rainTrackBar.Value = InTrackBarRange((int)(eventObject.rain * rainTrackBar.Maximum), rainTrackBar);
                 weatherRandomnessTrackBar.Value = InTrackBarRange(eventObject.weatherRandomness, weatherRandomnessTrackBar);
                 simracerWeatherConditionsCheckBox.Checked = eventObject.simracerWeatherConditions == 1 ? true : false;
                 fixedConditionQualificationCheckBox.Checked = eventObject.isFixedConditionQualification == 1 ? true : false;
@@ -442,8 +442,8 @@ namespace ACC_Dedicated_Server_GUI
             eventObject.postRaceSeconds = (int)postRaceWaitTimeNumericUpDown.Value;
             eventObject.sessionOverTimeSeconds = (int)overTimeNumericUpDown.Value;
             eventObject.ambientTemp = tempTrackBar.Value;
-            eventObject.cloudLevel = (float)cloudCoverageTrackBar.Value / 10;
-            eventObject.rain = (float)rainTrackBar.Value / 10;
+            eventObject.cloudLevel = (float)cloudCoverageTrackBar.Value / cloudCoverageTrackBar.Maximum;
+            eventObject.rain = (float)rainTrackBar.Value / rainTrackBar.Maximum;
             eventObject.weatherRandomness = weatherRandomnessTrackBar.Value;
             eventObject.isFixedConditionQualification = fixedConditionQualificationCheckBox.Checked ? 1 : 0;
             eventObject.simracerWeatherConditions = simracerWeatherConditionsCheckBox.Checked ? 1 : 0;

--- a/ACC Dedicated Server GUI/Properties/AssemblyInfo.cs
+++ b/ACC Dedicated Server GUI/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.2.8.6")]
-[assembly: AssemblyFileVersion("1.2.8.6")]
+[assembly: AssemblyVersion("1.2.8.7")]
+[assembly: AssemblyFileVersion("1.2.8.7")]

--- a/ACC Dedicated Server GUI/changelog.txt
+++ b/ACC Dedicated Server GUI/changelog.txt
@@ -1,4 +1,8 @@
-﻿V1.2.8.6
+﻿V1.2.8.7
+'Cloud Coverage' slider increments by 0.05
+'Rain Level' slider increments by 0.05
+----------------------------------------------------------------------
+V1.2.8.6
 Fixed an issue where ballast wasn't working correctly
 'Register To Lobby' now turns red if not checked
 ----------------------------------------------------------------------


### PR DESCRIPTION
I've noticed that the [simracing.gp](https://beta.simracing.gp/) platform allows setting cloud coverage and rain level by 0.05 and wanted to update the app to allow for setting up personal practice servers that more closely match what is configured by a league.